### PR TITLE
Fix: cursor centered

### DIFF
--- a/src/lib/Cursor.svelte
+++ b/src/lib/Cursor.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { onMount } from 'svelte';
 
+	const baseSize = 20;
 	export let size = 20;
 	export let color = 'black';
 	export let shape = 'circle';
@@ -8,9 +9,6 @@
 
 	let x = -100;
 	let y = -100;
-
-	const cx = size / 2;
-	const cy = size / 2;
 
 	onMount(() => {
 		/**
@@ -38,28 +36,37 @@
 	});
 </script>
 
-<div
-	class="custom-cursor {shape}"
-	style="left: {x - cx}px; top: {y -
-		cy}px;--size:{size}px; --mix-blend-mode: {mixBlendMode}; --background-color: {color}"
-/>
+<div class="cursor-wrapper" style="--x:{x}px; --y:{y}px">
+	<div
+		class="custom-cursor {shape}"
+		style="transform: translate(-50%, -50%) scale({size / baseSize}); width: {baseSize}px; height: {baseSize}px; --mix-blend-mode: {mixBlendMode}; --background-color: {color}"
+	/>
+</div>
 
 <style>
+	.cursor-wrapper {
+		--x: -100px;
+		--y: -100px;
+		position: fixed;
+
+		left: 0;
+		top: 0;
+		transform: translate(var(--x), var(--y));
+		pointer-events: none;
+		cursor: none;
+	}
 	.custom-cursor {
 		--background-color: 'black';
 		--mix-blend-mode: 'none';
-		--size: 20;
+		left: 50%;
+		top: 50%;
+
 		background-color: var(--background-color);
 		mix-blend-mode: var(--mix-blend-mode);
-		width: var(--size);
-		height: var(--size);
-		position: fixed;
 		border-radius: 50%;
-		pointer-events: none;
 		z-index: 99999;
 		/* Customize your cursor styles here */
-		transition: all 0.2s cubic-bezier(0.28, 0.8, 0.36, 1);
-		cursor: none;
+		transition: transform 0.2s cubic-bezier(0.28, 0.8, 0.36, 1);
 	}
 
 	.custom-cursor.square {


### PR DESCRIPTION
Cursor is now correctly centered. 

Avoid animating left, right, bottom, top, height, width when possible, especialy on mousemove even which trigger very often, those CSS property trigger reflow. Prefere instead transform properties. 

https://developer.mozilla.org/en-US/docs/Glossary/Reflow